### PR TITLE
Input `luametatexconfig.tex` in LuaMetaPlain

### DIFF
--- a/luametaplain.ini
+++ b/luametaplain.ini
@@ -4,7 +4,7 @@
 % PDF output by default.
 
 % Must be done first (as needs to 'tidy up')
-% \input luatexconfig.tex
+\input luametatexconfig.tex
 % Activate primitives
 \input luatexiniconfig.tex
 \begingroup


### PR DESCRIPTION
`luametaplain.ini` does not currently input `luametatexconfig.tex`. This means that code like
```tex
\showthe\pagewidth
```
shows `0.0pt` in LuaMetaPlain while LuaMetaLaTeX, LuaLaTeX, and LuaTeX all show the proper paper width.